### PR TITLE
Gitignore numtracker.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 Cargo.lock
 
 # Demo database and file number directories
-demo.db
+*.db
 trackers/


### PR DESCRIPTION
Gitignore numtracker.db to make the quickstart process as simple as possible.
.gitignore has a section for demo database files et al. which does not include numtracker.db, generated by the CLI by default.