### PR TITLE
Patch another breaking change in a graphql patch release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 unwrap_used = "deny"
 
 [dependencies]
-async-graphql = { version = "7.0.11", features = ["tracing"] }
-async-graphql-axum = "7.0.11"
+async-graphql = { version = "7.0.12", features = ["tracing"] }
+async-graphql-axum = "7.0.12"
 axum = "0.7.5"
 chrono = "0.4.38"
 clap = { version = "4.5.16", features = ["cargo", "derive", "env"] }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -388,6 +388,7 @@ where
             inaccessible: false,
             tags: vec![],
             specified_by_url: None,
+            directive_invocations: vec![],
         })
     }
 


### PR DESCRIPTION
async-graphql 7.0.12 added a new field to the MetaType::Scalar variant.
Add this field and bump the dependency to the new verrsion.

See https://github.com/async-graphql/async-graphql/issues/1645
